### PR TITLE
Replace make-empty-github-commit with @octokit/rest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,133 +4,171 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+    "@octokit/auth-token": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.4.tgz",
+      "integrity": "sha512-LNfGu3Ro9uFAYh10MUZVaT7X2CnNm2C8IDQmabx+3DygYIQjs9FwzFAHN/0t6mu5HEPhxcb1XOuxdpY82vCg2Q==",
       "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
+        "@octokit/types": "^6.0.0"
       }
     },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+    "@octokit/core": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.4.tgz",
+      "integrity": "sha512-d9dTsqdePBqOn7aGkyRFe7pQpCXdibSJ5SFnrTr0axevObZrpz3qkWm7t/NjYv5a66z6vhfteriaq4FRz3e0Qg==",
       "requires": {
-        "ms": "2.0.0"
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
       }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.10.tgz",
+      "integrity": "sha512-9+Xef8nT7OKZglfkOMm7IL6VwxXUQyR7DUSU0LH/F7VNqs8vyd7es5pTfz9E7DwUIx7R3pGscxu1EBhYljyu7Q==",
+      "requires": {
+        "@octokit/types": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.8.tgz",
+      "integrity": "sha512-WnCtNXWOrupfPJgXe+vSmprZJUr0VIu14G58PMlkWGj3cH+KLZEfKMmbUQ6C3Wwx6fdhzVW1CD5RTnBdUHxhhA==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-2.3.0.tgz",
+      "integrity": "sha512-Own8lHWVi5eEfLOnsIzAx16BoRbpkzac3QDUCxIqYMf4bjz+AGpv17UfRn1Va4lVmjwOpvZglpFI3mmxuQ+sIQ=="
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.7.1.tgz",
+      "integrity": "sha512-dUsxsEIrBqhlQNfXRhMhXOTQi0SSG38+QWcPGO226HFPFJk44vWukegHfMG3496vLv9T2oT7IuAGssGpcUg5bQ==",
+      "requires": {
+        "@octokit/types": "^6.3.1"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz",
+      "integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg=="
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.4.1.tgz",
+      "integrity": "sha512-+v5PcvrUcDeFXf8hv1gnNvNLdm4C0+2EiuWt9EatjjUmfriM1pTMM+r4j1lLHxeBQ9bVDmbywb11e3KjuavieA==",
+      "requires": {
+        "@octokit/types": "^6.1.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.12",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.12.tgz",
+      "integrity": "sha512-MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.4.tgz",
+      "integrity": "sha512-LjkSiTbsxIErBiRh5wSZvpZqT4t0/c9+4dOe0PII+6jXR+oj/h66s7E4a/MghV7iT8W9ffoQ5Skoxzs96+gBPA==",
+      "requires": {
+        "@octokit/types": "^6.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.12.tgz",
+      "integrity": "sha512-hNRCZfKPpeaIjOVuNJzkEL6zacfZlBPV8vw8ReNeyUkVvbuCvvrrx8K8Gw2eyHHsmd4dPlAxIXIZ9oHhJfkJpw==",
+      "requires": {
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "4.4.1"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.3.1.tgz",
+      "integrity": "sha512-SyOaprLWVPS6QhbZY8hF9Oydx/UUnslKq1NyNUr4CN42UEPC3+9AvrYrDm4UvaU1D5u/vVMuSZOicFqOielRXQ==",
+      "requires": {
+        "@octokit/openapi-types": "^2.3.0",
+        "@types/node": ">= 8"
+      }
+    },
+    "@types/node": {
+      "version": "14.14.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.21.tgz",
+      "integrity": "sha512-cHYfKsnwllYhjOzuC5q1VpguABBeecUp24yFluHpn/BQaVxB1CuQ1FSRZCzrPxrkIfWISXV2LbeoBthLWg0+0A=="
+    },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "dotenv": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "follow-redirects": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
-      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
-      "requires": {
-        "debug": "^2.2.0",
-        "stream-consume": "^0.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "github": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/github/-/github-11.0.0.tgz",
-      "integrity": "sha1-7bMt9e+zPK0ATr8L3SpLMLtjqFQ=",
-      "requires": {
-        "follow-redirects": "0.0.7",
-        "https-proxy-agent": "^1.0.0",
-        "mime": "^1.2.11",
-        "netrc": "^0.1.4"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-      "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "lambda-api": {
       "version": "0.10.6",
       "resolved": "https://registry.npmjs.org/lambda-api/-/lambda-api-0.10.6.tgz",
       "integrity": "sha512-Tjn5GQEI4N1a3CojgphpwQX/2692czUykRoG2bnTIgZ6hnRiMea+KlWatD77r4HwF66Uj6xgOOs8YG+jC3xuQg=="
     },
-    "make-empty-github-commit": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/make-empty-github-commit/-/make-empty-github-commit-1.2.1.tgz",
-      "integrity": "sha512-lOZ/CPWEDbao3oaLai1bc1+YQcNKW5eTKrOcG+LF3EXkyj0/Xw6W2PIv+4ZtOJRkLAiyLvZ9/Z+pfr8jV5PAPw==",
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "debug": "3.1.0",
-        "github": "11.0.0",
-        "minimist": "1.2.5",
-        "parse-github-repo-url": "1.4.1"
+        "wrappy": "1"
       }
     },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "netrc": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
-      "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ="
-    },
-    "parse-github-repo-url": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-      "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
-    },
-    "semver": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-      "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
-    },
-    "stream-consume": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg=="
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "@octokit/rest": "^18.0.12",
     "dotenv": "^8.2.0",
-    "lambda-api": "^0.10.6",
-    "make-empty-github-commit": "^1.2.1"
+    "lambda-api": "^0.10.6"
   }
 }

--- a/src/routes/release.js
+++ b/src/routes/release.js
@@ -7,7 +7,7 @@ const {
 } = process.env
 
 const crypto = require('crypto')
-const emptyGitHubCommit = require('make-empty-github-commit')
+const { bumpBranch } = require('../utils/github.js')
 
 module.exports = (api) => {
   api.post('/release', async (req, res) => {
@@ -38,12 +38,11 @@ module.exports = (api) => {
       return res.status(403).send({ committed: false })
     }
 
-    const { sha } = await emptyGitHubCommit({
+    const { sha } = await bumpBranch({
       owner: GITHUB_USERNAME,
       repo: GITHUB_REPO,
-      token: GITHUB_PERSONAL_TOKEN,
+      branch: `v${version}`,
       message: `${project}:${version} was pushed to Docker Hub.`,
-      branch: `v${version}`
     })
     req.log.info('Published git commit', { sha })
 

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -1,0 +1,54 @@
+const {
+  GITHUB_PERSONAL_TOKEN = '',
+} = process.env
+
+const { Octokit } = require("@octokit/rest")
+
+exports.octokit = new Octokit({
+  auth: GITHUB_PERSONAL_TOKEN,
+})
+
+/**
+ *
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} branch
+ * @param {string} message Commit message
+ */
+exports.bumpBranch = async ({ owner, repo, branch, message }) => {
+  // First we need to figure out the latest sha1 in the branch
+  const { data: branchRef } = await this.octokit.git.getRef({
+    owner,
+    repo,
+    ref: `heads/${branch}`
+  })
+  const latestCommitSha = branchRef.object.sha
+
+  // Since we want to make no changes, we can reuse the same tree object
+  // (Tree objects are basically the directory state for your repository)
+  const { data: latestCommit } = await this.octokit.git.getCommit({
+    owner,
+    repo,
+    commit_sha: latestCommitSha,
+  })
+  const treeSha = latestCommit.tree.sha
+
+  // Now we can create a commit that points to the same tree, with the previous commit as its parent.
+  const { data: newCommit } = await this.octokit.git.createCommit({
+    owner,
+    repo,
+    message,
+    tree: treeSha,
+    parents: [ latestCommitSha ]
+  })
+
+  // Yay. Now all we need to do is make sure refs/heads/{branch} points to the new commit.
+  await this.octokit.git.updateRef({
+    owner,
+    repo,
+    ref: `heads/${branch}`,
+    sha: newCommit.sha,
+  })
+
+  return newCommit
+}


### PR DESCRIPTION
`make-empty-github-commit` sends the token in a querystring parameter to the API; this behavior is deprecated in favor of using an `Authorization` HTTP header. Since `@octokit/rest` does that by default and is officially supported by Github, this PR cuts out the middleman.